### PR TITLE
Get hints of uncompleted but unique blocknames

### DIFF
--- a/SmartHints.py
+++ b/SmartHints.py
@@ -60,7 +60,17 @@ class SmartHint(sublime_plugin.ViewEventListener):
         # Arguments description for current block
         block_hints = self.hints.get(blockname)
         if not block_hints:
-            return
+            excepted_blockname = ""
+            for name in self.hints.keys():
+                if name.find(blockname, 0, len(blockname)) != -1:
+                    if not excepted_blockname:
+                        excepted_blockname = name
+                    else:
+                        excepted_blockname = ""
+                        break
+            block_hints = self.hints.get(excepted_blockname)
+            if not block_hints:
+                return
 
         # Try to get description for current argument
         try:

--- a/SmartHints.py
+++ b/SmartHints.py
@@ -60,15 +60,15 @@ class SmartHint(sublime_plugin.ViewEventListener):
         # Arguments description for current block
         block_hints = self.hints.get(blockname)
         if not block_hints:
-            excepted_blockname = ""
+            expected_blockname = ""
             for name in self.hints.keys():
-                if name.find(blockname, 0, len(blockname)) != -1:
-                    if not excepted_blockname:
-                        excepted_blockname = name
+                if name.find(blockname) == 0:
+                    if not expected_blockname:
+                        expected_blockname = name
                     else:
-                        excepted_blockname = ""
+                        expected_blockname = ""
                         break
-            block_hints = self.hints.get(excepted_blockname)
+            block_hints = self.hints.get(expected_blockname)
             if not block_hints:
                 return
 


### PR DESCRIPTION
This code allows to get hints of uncompleted blocknames, that have only one coincidence with the blocknames dictionary.
For example:
if I write blockname "TE" it will not display any hints for arguments, coz have more than one option ("TEST", "TERMINATE");
but if I write "TER" it will display hints, coz have only one option in the dictionary "TERMINATE".
